### PR TITLE
File.seek()'s second argument 'whence' do not accept 16.

### DIFF
--- a/dexParser.py
+++ b/dexParser.py
@@ -345,7 +345,7 @@ class DexFile(object):
 
     def print_DexProtoId(self):
         proto_ids_off_int = int(self.DexHeader.proto_ids_off, 16)
-        self.DexHeader.f.seek(proto_ids_off_int, 16)
+        self.DexHeader.f.seek(proto_ids_off_int, 0)
         print '\n'
         print '[+] DexProtoId:'
         for index in range(len(self.DexProtoIdList)):


### PR DESCRIPTION
dex_parser.py is used and something wrong happened:

```bash
Traceback (most recent call last):
  File "dex_parser.py", in <module>
    main()
  File "dex_parser.py", in main
    dex.print_DexProtoId()
  File "dex_parser.py", in print_DexProtoId
    self.DexHeader.f.seek(proto_ids_off_int, 16)
IOError: [Errno 22] Invalid argument
```

As I search for the declaration, I got fileObject.seek(offset[, whence]) and whence should only be 0, 1, or 2.
It should not be 16. 
I was wondering if it is a bug.
